### PR TITLE
Pull Request link fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Contributing
 4. Push to the branch `git push origin my_markup`
 5. Open a [Pull Request][1]
 6. Enjoy a refreshing `Insert Favorite Beverage` and wait
+
+[1]: https://github.com/acrogenesis/macchanger/pulls


### PR DESCRIPTION
This is a link to the PRs page because there’s no generic "make a PR on the original repo from my fork", it always contains the user’s name (e.g. `/bfontaine/macchanger/compare/acrogenesis:master...master`).
